### PR TITLE
Update bionic apt dependencies to use openjdk-jre-8-headless

### DIFF
--- a/lib/charms/layer/jenkins/packages.py
+++ b/lib/charms/layer/jenkins/packages.py
@@ -15,7 +15,7 @@ apt = try_import("charms.apt")
 
 APT_DEPENDENCIES = {
     "xenial": ["daemon", "default-jre-headless"],
-    "bionic": ["daemon", "openjdk-11-jre-headless"],
+    "bionic": ["daemon", "openjdk-8-jre-headless"],
 }
 APT_SOURCE = "deb http://pkg.jenkins-ci.org/%s binary/"
 


### PR DESCRIPTION
I deployed this branch with openjdk-jre-8-headless on Bionic and have a working jenkins master:

```
ubuntu@juju-488cdb-default-38:~$ java -version
openjdk version "1.8.0_191"
OpenJDK Runtime Environment (build 1.8.0_191-8u191-b12-2ubuntu0.18.04.1-b12)
OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)

ubuntu@juju-488cdb-default-38:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.2 LTS
Release:        18.04
Codename:       bionic
```

I also deployed cs:jenkins-slave to a bionic VM and hooked them up successfully.